### PR TITLE
Add cargo steps percentile

### DIFF
--- a/lacam/include/instance.hpp
+++ b/lacam/include/instance.hpp
@@ -8,10 +8,13 @@
 #include "utils.hpp"
 
 struct Instance {
-  Graph graph;          // graph
-  Config starts;        // initial configuration
-  Config goals;         // goal configuration, can be in warehouse block/cache block
-  Config cargo_goals;   // cargo goal configuration
+  Graph graph;                    // graph
+  Config starts;                  // initial configuration
+  Config goals;                   // goal configuration, can be in warehouse block/cache block
+  Config cargo_goals;             // cargo goal configuration
+
+  std::vector<uint> cargo_cnts;   // each cargo cnts, help variable for cargo_steps
+  std::vector<uint> cargo_steps;  // each cargo steps 
 
   // Status control:
   // 0 -> cache miss, going for warehouse get cargo
@@ -21,8 +24,8 @@ struct Instance {
   // 4 -> cache get cargo, going back to unloading port
   std::vector<uint> bit_status;
 
-  const uint nagents;   // number of agents
-  const uint ngoals;    // number of goals
+  const uint nagents;             // number of agents
+  const uint ngoals;              // number of goals
 
   std::shared_ptr<spdlog::logger> logger;
 
@@ -56,4 +59,7 @@ struct Instance {
     std::vector<Config>& vertex_list,
     int remain_goals
   );
+
+  // Compute percentiles steps
+  std::vector<uint> compute_percentiles() const;
 };

--- a/tools/experiment/warehouse_withcache.yaml
+++ b/tools/experiment/warehouse_withcache.yaml
@@ -1,6 +1,6 @@
 map: "assets/warehouse/with_cache/warehouse-10-20-10-2-1_half_reduce.map"
 cache: ["LRU", "FIFO", "RANDOM"]
-ngoals: [1000]
+ngoals: [10000]
 goals_k: [20, 40, 60, 80]
 goals_m: [100]
 nagents: [5, 10, 20]

--- a/tools/experiment/warehouse_withoutcache.yaml
+++ b/tools/experiment/warehouse_withoutcache.yaml
@@ -1,6 +1,6 @@
 map: "assets/warehouse/without_cache/warehouse-10-20-10-2-1_half_reduce.map"
 cache: ["NONE"]
-ngoals: [1000]
+ngoals: [10000]
 goals_k: [20, 40, 60, 80]
 goals_m: [100]
 nagents: [5, 10, 20]


### PR DESCRIPTION
In this PR, we add a new monitor variable `cargo_step_percentile`, we record `ngoals` of cargo steps and find first 0%, 50% and 99% of them. This variable can reflect how quick we can solve a cargo.